### PR TITLE
Fix creation of dynamic property is deprecated warning

### DIFF
--- a/src/CensorWords.php
+++ b/src/CensorWords.php
@@ -5,6 +5,7 @@ namespace Snipe\BanBuilder;
 class CensorWords
 {
     public $badwords;
+    private $replacer = '*';
 
     /*
     * When the dictionary is loaded, a ton of regular expression strings are generated


### PR DESCRIPTION
Fix for:

`PHP Deprecated:  Creation of dynamic property Snipe\BanBuilder\CensorWords::$replacer is deprecated in /vendor/snipe/banbuilder/src/CensorWords.php on line 29`